### PR TITLE
rfc, generalized-type-ascription: add `if let` example.

### DIFF
--- a/text/0000-generalized-type-ascription.md
+++ b/text/0000-generalized-type-ascription.md
@@ -222,7 +222,17 @@ match expr {
 }
 ```
 
-In the last case, the typing annotation is both *most local* and also does not
+or analogously:
+
+```rust
+if let Some(vec: Vec<u8>) = expr {
+    logic
+} else {
+    logic
+}
+```
+
+In the last two cases, the typing annotation is both *most local* and also does not
 require you to annotate information that is both obvious to the reader
 (who is familiar with `Option<T>`) and to the compiler
 (that `expr : Option<?T>` for some `?T`).


### PR DESCRIPTION
This adds another example using `if let` in combination with type ascription.